### PR TITLE
Add DoctrineORMBridge marker class

### DIFF
--- a/src/DoctrineORMBridge/DoctrineORMBridge.php
+++ b/src/DoctrineORMBridge/DoctrineORMBridge.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\DoctrineORMBridge;
+
+/**
+ * Aa marker class, indicated, that "trollbus/doctrine-orm-bridge" package is installed.
+ */
+final class DoctrineORMBridge
+{
+    private function __construct() {}
+}


### PR DESCRIPTION
DoctrineORMBridge is marker class, indicates, that `trollbus/doctrine-orm-bridge` package is installed.