### PR TITLE
EntityFactoryHandler

### DIFF
--- a/src/MessageBus/EntityHandler/EntityFactoryHandler.php
+++ b/src/MessageBus/EntityHandler/EntityFactoryHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\EntityHandler;
+
+use Trollbus\Message\Message;
+use Trollbus\MessageBus\Handler;
+use Trollbus\MessageBus\MessageContext;
+
+/**
+ * @template TMessage of Message<void>
+ *
+ * @implements Handler<void, TMessage>
+ */
+final class EntityFactoryHandler implements Handler
+{
+    /**
+     * @param non-empty-string $id
+     * @param class-string $entityClass
+     * @param non-empty-string $handlerMethod static handler method, that handle `Trollbus\Message\Message<void>`
+     *                                        message and return entity instance
+     */
+    public function __construct(
+        private readonly string $id,
+        private readonly EntitySaver $saver,
+        private readonly string $entityClass,
+        private readonly string $handlerMethod,
+    ) {}
+
+    #[\Override]
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    #[\Override]
+    public function handle(MessageContext $messageContext): mixed
+    {
+        /**
+         * @psalm-suppress MixedMethodCall
+         * @var object $entity
+         */
+        $entity = $this->entityClass::{$this->handlerMethod}($messageContext->getMessage(), $messageContext);
+
+        $this->saver->save($entity);
+
+        return null;
+    }
+}

--- a/src/TrollbusBundle/DependencyInjection/MessageBusConfigurator.php
+++ b/src/TrollbusBundle/DependencyInjection/MessageBusConfigurator.php
@@ -6,6 +6,7 @@ namespace Trollbus\TrollbusBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Trollbus\Message\Message;
+use Trollbus\MessageBus\EntityHandler\EntityFactoryHandler;
 use Trollbus\MessageBus\EntityHandler\EntityHandler;
 use Trollbus\MessageBus\Handler\CallableHandler;
 use Trollbus\MessageBus\Middleware\HandlerWithMiddlewares;
@@ -125,6 +126,37 @@ final class MessageBusConfigurator
                     $handlerMethod,
                     $findBy,
                     $factoryMethod,
+                ]);
+
+        return $this->handler($message, $handlerService, $middlewares);
+    }
+
+    /**
+     * @param class-string<Message<void>> $message
+     * @param class-string $entityClass
+     * @param non-empty-string $handlerMethod static handler method, that handle `Trollbus\Message\Message<void>`
+     *                                        message and return entity instance
+     * @param non-empty-string $entitySaver
+     * @param non-empty-string|null $handlerId
+     * @param list<non-empty-string> $middlewares
+     */
+    public function entityFactoryHandler(
+        string $message,
+        string $entityClass,
+        string $handlerMethod,
+        string $entitySaver = self::DEFAULT_ENTITY_SAVER,
+        ?string $handlerId = null,
+        array $middlewares = [],
+    ): self {
+        $handlerService = self::nextHandlerService();
+        $this->di
+            ->services()
+            ->set($handlerService, EntityFactoryHandler::class)
+                ->args([
+                    $handlerId ?? $handlerService,
+                    service($entitySaver),
+                    $entityClass,
+                    $handlerMethod,
                 ]);
 
         return $this->handler($message, $handlerService, $middlewares);

--- a/tests/DoctrineORMBridge/EntityHandler/CreateEntityWithFactoryMethod.php
+++ b/tests/DoctrineORMBridge/EntityHandler/CreateEntityWithFactoryMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\DoctrineORMBridge\EntityHandler;
+
+use Trollbus\Message\Message;
+
+/**
+ * @implements Message<void>
+ */
+final class CreateEntityWithFactoryMethod implements Message
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $title,
+    ) {}
+}

--- a/tests/DoctrineORMBridge/EntityHandler/DoctrineEntityFinderAndSaverTest.php
+++ b/tests/DoctrineORMBridge/EntityHandler/DoctrineEntityFinderAndSaverTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\OptimisticLockException;
 use PHPUnit\Framework\TestCase;
 use Trollbus\DoctrineORMBridge\EntityHandler\DoctrineEntityFinder;
 use Trollbus\DoctrineORMBridge\EntityHandler\DoctrineEntitySaver;
+use Trollbus\MessageBus\EntityHandler\EntityFactoryHandler;
 use Trollbus\MessageBus\EntityHandler\EntityHandler;
 use Trollbus\MessageBus\EntityHandler\EntityNotFound;
 use Trollbus\MessageBus\EntityHandler\PropertyCriteriaResolver;
@@ -104,6 +105,32 @@ final class DoctrineEntityFinderAndSaverTest extends TestCase
         self::assertSame('Title', $savedEntity->getTitle());
 
         self::assertSame('Old title', $entity->getTitle());
+    }
+
+    public function testEntityWithFactoryMethod(): void
+    {
+        $messageBus = new MessageBus(
+            handlerRegistry: new ClassStringMapHandlerRegistry(
+                (new ClassStringMap())->with(
+                    messageClass: CreateEntityWithFactoryMethod::class,
+                    handler: new EntityFactoryHandler(
+                        id: 'entity',
+                        saver: new DoctrineEntitySaver($this->doctrine, true),
+                        entityClass: EntityWithFactoryMethod::class,
+                        handlerMethod: 'createEntity',
+                    ),
+                ),
+            ),
+        );
+        $messageBus->dispatch(new CreateEntityWithFactoryMethod(id: '1', title: 'Title'));
+
+        $em = $this->doctrine->getManager();
+        $em->clear();
+        $entity = $em->find(EntityWithFactoryMethod::class, '1');
+
+        self::assertInstanceOf(EntityWithFactoryMethod::class, $entity);
+        self::assertSame('1', $entity->getId());
+        self::assertSame('Title', $entity->getTitle());
     }
 
     private function createMessageBus(bool $useFactoryMethod, bool $saverFlush): MessageBus

--- a/tests/DoctrineORMBridge/EntityHandler/EntityWithFactoryMethod.php
+++ b/tests/DoctrineORMBridge/EntityHandler/EntityWithFactoryMethod.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\DoctrineORMBridge\EntityHandler;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @final
+ */
+#[ORM\Entity]
+class EntityWithFactoryMethod
+{
+    private function __construct(
+        #[ORM\Id]
+        #[ORM\Column(type: 'string')]
+        private readonly string $id,
+        #[ORM\Column(type: 'string')]
+        private string $title = '',
+    ) {}
+
+    public static function createEntity(CreateEntityWithFactoryMethod $command): self
+    {
+        return new self(
+            id: $command->id,
+            title: $command->title,
+        );
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+}

--- a/tests/MessageBus/MessageBusTest.php
+++ b/tests/MessageBus/MessageBusTest.php
@@ -7,6 +7,7 @@ namespace Trollbus\Tests\MessageBus;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Trollbus\MessageBus\CreatedAt\CreatedAtMiddleware;
+use Trollbus\MessageBus\EntityHandler\EntityFactoryHandler;
 use Trollbus\MessageBus\EntityHandler\EntityHandler;
 use Trollbus\MessageBus\EntityHandler\EntityNotFound;
 use Trollbus\MessageBus\EntityHandler\PropertyCriteriaResolver;
@@ -25,6 +26,10 @@ use Trollbus\MessageBus\MessageId\MessageIdNotSet;
 use Trollbus\MessageBus\Middleware\HandlerWithMiddlewares;
 use Trollbus\MessageBus\Transaction\FakeTransactionProvider;
 use Trollbus\MessageBus\Transaction\WrapInTransactionMiddleware;
+use Trollbus\Tests\MessageBus\MessageBusTestCases\EntityFactoryHandler\CreateEntityWithFactoryMethod;
+use Trollbus\Tests\MessageBus\MessageBusTestCases\EntityFactoryHandler\EntityWithFactoryMethod;
+use Trollbus\Tests\MessageBus\MessageBusTestCases\EntityFactoryHandler\EntityWithFactoryMethodCreated;
+use Trollbus\Tests\MessageBus\MessageBusTestCases\EntityFactoryHandler\InMemoryEntityWithFactoryMethodSaver;
 use Trollbus\Tests\MessageBus\MessageBusTestCases\EntityHandler\EditEntity;
 use Trollbus\Tests\MessageBus\MessageBusTestCases\EntityHandler\Entity;
 use Trollbus\Tests\MessageBus\MessageBusTestCases\EntityHandler\EntityEdited;
@@ -417,6 +422,46 @@ final class MessageBusTest extends TestCase
             correlationId: '1',
             causationId: '1',
         );
+    }
+
+    public function testEntityFactoryHandler(): void
+    {
+        $saver = new InMemoryEntityWithFactoryMethodSaver();
+        $handler = new EntityFactoryHandler(
+            id: EntityFactoryHandler::class,
+            saver: $saver,
+            entityClass: EntityWithFactoryMethod::class,
+            handlerMethod: 'createEntity',
+        );
+        $event = null;
+        /** @var CallableHandler<void, EntityWithFactoryMethodCreated> $eventHandler */
+        $eventHandler = new CallableHandler(
+            id: 'created_entity_handler',
+            handler: static function (EntityWithFactoryMethodCreated $e) use (&$event): void {
+                $event = $e;
+            },
+        );
+        $eventHandler = new EventHandler([$eventHandler]);
+
+        $messageBus = $this->createMessageBus(
+            (new ClassStringMap())
+                ->with(CreateEntityWithFactoryMethod::class, $handler)
+                ->with(EntityWithFactoryMethodCreated::class, $eventHandler),
+        );
+
+        $command = new CreateEntityWithFactoryMethod(id: '1', title: 'Title');
+
+        $messageBus->dispatch($command);
+
+        $entity = $saver->entities['1'] ?? null;
+
+        self::assertInstanceOf(EntityWithFactoryMethod::class, $entity);
+        self::assertSame('1', $entity->id);
+        self::assertSame('Title', $entity->title);
+
+        self::assertInstanceOf(EntityWithFactoryMethodCreated::class, $event);
+        self::assertSame('1', $event->id);
+        self::assertSame('Title', $event->title);
     }
 
     public function testDispatchThrowsHandlerNotFound(): void

--- a/tests/MessageBus/MessageBusTestCases/EntityFactoryHandler/CreateEntityWithFactoryMethod.php
+++ b/tests/MessageBus/MessageBusTestCases/EntityFactoryHandler/CreateEntityWithFactoryMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\MessageBus\MessageBusTestCases\EntityFactoryHandler;
+
+use Trollbus\Message\Message;
+
+/**
+ * @implements Message<void>
+ */
+final class CreateEntityWithFactoryMethod implements Message
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $title,
+    ) {}
+}

--- a/tests/MessageBus/MessageBusTestCases/EntityFactoryHandler/EntityWithFactoryMethod.php
+++ b/tests/MessageBus/MessageBusTestCases/EntityFactoryHandler/EntityWithFactoryMethod.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\MessageBus\MessageBusTestCases\EntityFactoryHandler;
+
+use Trollbus\MessageBus\MessageContext;
+
+final class EntityWithFactoryMethod
+{
+    private function __construct(
+        public readonly string $id,
+        public readonly string $title,
+    ) {}
+
+    /**
+     * @param MessageContext<void, CreateEntityWithFactoryMethod> $messageContext
+     */
+    public static function createEntity(CreateEntityWithFactoryMethod $command, MessageContext $messageContext): self
+    {
+        $entity = new self(
+            id: $command->id,
+            title: $command->title,
+        );
+
+        $messageContext->dispatch(new EntityWithFactoryMethodCreated(
+            id: $entity->id,
+            title: $entity->title,
+        ));
+
+        return $entity;
+    }
+}

--- a/tests/MessageBus/MessageBusTestCases/EntityFactoryHandler/EntityWithFactoryMethodCreated.php
+++ b/tests/MessageBus/MessageBusTestCases/EntityFactoryHandler/EntityWithFactoryMethodCreated.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\MessageBus\MessageBusTestCases\EntityFactoryHandler;
+
+use Trollbus\Message\Event;
+
+final class EntityWithFactoryMethodCreated implements Event
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $title,
+    ) {}
+}

--- a/tests/MessageBus/MessageBusTestCases/EntityFactoryHandler/InMemoryEntityWithFactoryMethodSaver.php
+++ b/tests/MessageBus/MessageBusTestCases/EntityFactoryHandler/InMemoryEntityWithFactoryMethodSaver.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\MessageBus\MessageBusTestCases\EntityFactoryHandler;
+
+use Trollbus\MessageBus\EntityHandler\EntitySaver;
+
+final class InMemoryEntityWithFactoryMethodSaver implements EntitySaver
+{
+    /** @var array<EntityWithFactoryMethod> */
+    public array $entities = [];
+
+    #[\Override]
+    public function save(object $entity): void
+    {
+        if (!$entity instanceof EntityWithFactoryMethod) {
+            throw new \InvalidArgumentException('Invalid criteria.');
+        }
+
+        $this->entities[$entity->id] = $entity;
+    }
+}

--- a/tests/TrollbusBundle/TrollbusBundleTest.php
+++ b/tests/TrollbusBundle/TrollbusBundleTest.php
@@ -22,8 +22,10 @@ use Trollbus\MessageBus\MessageId\CorrelationId;
 use Trollbus\MessageBus\MessageId\MessageId;
 use Trollbus\MessageBus\MessageId\MessageIdNotSet;
 use Trollbus\MessageBus\Transaction\InTransaction;
+use Trollbus\Tests\DoctrineORMBridge\EntityHandler\CreateEntityWithFactoryMethod;
 use Trollbus\Tests\DoctrineORMBridge\EntityHandler\EditEntity;
 use Trollbus\Tests\DoctrineORMBridge\EntityHandler\Entity;
+use Trollbus\Tests\DoctrineORMBridge\EntityHandler\EntityWithFactoryMethod;
 use Trollbus\Tests\DoctrineORMBridge\ManagerRegistry;
 use Trollbus\Tests\MessageBus\MessageBusAssert;
 use Trollbus\Tests\MessageBus\MessageBusTestCases\EventHandler\SomeEvent;
@@ -320,6 +322,38 @@ final class TrollbusBundleTest extends TestCase
         self::assertInstanceOf(Entity::class, $entity);
         self::assertSame('1', $entity->getId());
         self::assertSame('Title 2', $entity->getTitle());
+    }
+
+    public function testEntityFactoryHandlerFromDoctrineORMBridge(): void
+    {
+        $container = $this->createContainerWithAllEnabledConfigs(static function (ContainerConfigurator $di): void {
+            $messageBusConfigurator = MessageBusConfigurator::create($di);
+
+            $messageBusConfigurator->entityFactoryHandler(
+                message: CreateEntityWithFactoryMethod::class,
+                entityClass: EntityWithFactoryMethod::class,
+                handlerMethod: 'createEntity',
+            );
+        });
+        /** @var MessageBus $messageBus */
+        $messageBus = $container->get('trollbus');
+        /** @var ManagerRegistry $doctrine */
+        $doctrine = $container->get('doctrine');
+        $doctrine->createSchema();
+
+        self::assertNull($doctrine->getManager()->find(EntityWithFactoryMethod::class, '1'));
+
+        $messageBus->dispatch(new CreateEntityWithFactoryMethod(
+            id: '1',
+            title: 'Title',
+        ));
+
+        $doctrine->resetManager();
+        $entity =  $doctrine->getManager()->find(EntityWithFactoryMethod::class, '1');
+
+        self::assertInstanceOf(EntityWithFactoryMethod::class, $entity);
+        self::assertSame('1', $entity->getId());
+        self::assertSame('Title', $entity->getTitle());
     }
 
     /**


### PR DESCRIPTION
EntityFactoryHandler create message handler from static entity method. It must be use for create new entity instance with message bus.

Supports only messages with type `Message<void>`.
Static method must be return entity instance, 

**Example**

Entity class:

```php
/**
 * @implements Message<void>
 */
class CreateEntity implements Message
{
    public function __construcor(
        private Uuid $id,
        private string $title,
    ) {}
}

class Entity
{
    private function __construcor(
        private Uuid $id,
        private string $title,
    ) {}

    public static function createEntity(CreateEntity $command): self
    {
        return new self(
            id: $command->id,
            title: $command->title,
        );
    }
}
```

Create handler, using symfony framework:

```php
use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
use Trollbus\TrollbusBundle\DependencyInjection\MessageBusConfigurator;

return static function(ContainerConfigurator $container): void {
    MessageBusConfigurator::create($container)
        ->entityFactoryHandler(
            message: CreateEntity::class,
            entityClass: Entity::class,
            handlerMethod: 'createEntity',
        );
};
```