### PR TITLE
Create MessageBusConfiguration, refactor existing code, using it

### DIFF
--- a/src/TrollbusBundle/DependencyInjection/CompilerPass/DebugHandlerPass.php
+++ b/src/TrollbusBundle/DependencyInjection/CompilerPass/DebugHandlerPass.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Trollbus\Message\Message;
 use Trollbus\MessageBus\Middleware\HandlerWithMiddlewares;
 use Trollbus\TrollbusBundle\Command\DebugCommand;
-use Trollbus\TrollbusBundle\DependencyInjection\MessageBusConfigurator;
+use Trollbus\TrollbusBundle\DependencyInjection\MessageBusConfiguration;
 
 final class DebugHandlerPass implements CompilerPassInterface
 {
@@ -32,13 +32,13 @@ final class DebugHandlerPass implements CompilerPassInterface
         /** @var array<non-empty-string, list<non-empty-string>> $handlerServiceIdMiddlewares */
         $handlerServiceIdMiddlewares = [];
 
-        foreach ($container->findTaggedServiceIds(MessageBusConfigurator::HANDLER_TAG) as $serviceId => $tags) {
+        foreach ($container->findTaggedServiceIds(MessageBusConfiguration::HANDLER_TAG) as $serviceId => $tags) {
             $handlerServiceIds[] = $serviceId;
 
             /** @var array $tag */
             foreach ($tags as $tag) {
                 /** @var class-string<Message> $messageClass */
-                $messageClass = (string) ($tag[MessageBusConfigurator::HANDLER_TAG_MESSAGE] ?? '');
+                $messageClass = (string) ($tag[MessageBusConfiguration::HANDLER_TAG_MESSAGE] ?? '');
 
                 $messageClassToHandlerServiceIds[$messageClass][] = $serviceId;
             }
@@ -70,7 +70,7 @@ final class DebugHandlerPass implements CompilerPassInterface
         $middlewares = [];
 
         /** @var non-empty-string $serviceId */
-        foreach ($container->findTaggedServiceIds(MessageBusConfigurator::MIDDLEWARE_TAG) as $serviceId => $tags) {
+        foreach ($container->findTaggedServiceIds(MessageBusConfiguration::MIDDLEWARE_TAG) as $serviceId => $tags) {
             $middlewares[] = $serviceId;
         }
 

--- a/src/TrollbusBundle/DependencyInjection/CompilerPass/HandlerRegistryPass.php
+++ b/src/TrollbusBundle/DependencyInjection/CompilerPass/HandlerRegistryPass.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Trollbus\Message\Event;
 use Trollbus\Message\Message;
 use Trollbus\MessageBus\Handler\EventHandler;
-use Trollbus\TrollbusBundle\DependencyInjection\MessageBusConfigurator;
+use Trollbus\TrollbusBundle\DependencyInjection\MessageBusConfiguration;
 use Trollbus\TrollbusBundle\HandlerRegistry\ContainerHandlerRegistry;
 
 final class HandlerRegistryPass implements CompilerPassInterface
@@ -38,13 +38,13 @@ final class HandlerRegistryPass implements CompilerPassInterface
                 throw new LogicException(\sprintf('Non-event message %s must have 1 handler, got %s', $message, \count($ids)));
             }
 
-            $id = MessageBusConfigurator::nextHandlerService();
+            $id = MessageBusConfiguration::nextHandlerService();
             $container->setDefinition($id, new Definition(EventHandler::class, [array_map(static fn($handlerId) => new Reference($handlerId), $ids)]));
             $messageToHandlerMap[$message] = new Reference($id);
         }
 
         $container->setDefinition(
-            MessageBusConfigurator::HANDLER_REGISTRY,
+            MessageBusConfiguration::HANDLER_REGISTRY,
             new Definition(
                 ContainerHandlerRegistry::class,
                 [
@@ -59,7 +59,7 @@ final class HandlerRegistryPass implements CompilerPassInterface
      */
     private function getMessageToHandlerIdsMap(ContainerBuilder $container): array
     {
-        $handlerTag = MessageBusConfigurator::HANDLER_TAG;
+        $handlerTag = MessageBusConfiguration::HANDLER_TAG;
 
         /** @var array<class-string<Message>, list<non-empty-string>> $messageToHandlerIdsMap */
         $messageToHandlerIdsMap = [];
@@ -72,12 +72,12 @@ final class HandlerRegistryPass implements CompilerPassInterface
 
             /** @var array $tag */
             foreach ($definition->getTag($handlerTag) as $tag) {
-                $messageClass = (string) ($tag[MessageBusConfigurator::HANDLER_TAG_MESSAGE]
+                $messageClass = (string) ($tag[MessageBusConfiguration::HANDLER_TAG_MESSAGE]
                     ?? throw new LogicException(\sprintf(
                         'Service "%s" tagged by "%s" requires tag attribute "%s".',
                         $id,
                         $handlerTag,
-                        MessageBusConfigurator::HANDLER_TAG_MESSAGE,
+                        MessageBusConfiguration::HANDLER_TAG_MESSAGE,
                     )));
 
                 $messageClass = self::getFqcn($messageClass);
@@ -88,7 +88,7 @@ final class HandlerRegistryPass implements CompilerPassInterface
                         $id,
                         $handlerTag,
                         $messageClass,
-                        MessageBusConfigurator::HANDLER_TAG_MESSAGE,
+                        MessageBusConfiguration::HANDLER_TAG_MESSAGE,
                     ));
                 }
 

--- a/src/TrollbusBundle/DependencyInjection/MessageBusConfiguration.php
+++ b/src/TrollbusBundle/DependencyInjection/MessageBusConfiguration.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\TrollbusBundle\DependencyInjection;
+
+final class MessageBusConfiguration
+{
+    public const MESSAGE_BUS = 'trollbus';
+    public const HANDLER_REGISTRY = 'trollbus.handler_registry';
+    public const HANDLER_TAG = 'trollbus.handler';
+    public const HANDLER_TAG_MESSAGE = 'message';
+    public const HANDLER_TAG_MIDDLEWARES = 'middlewares';
+    public const MIDDLEWARE_TAG = 'trollbus.middleware';
+    public const DEFAULT_MESSAGE_ID_GENERATOR = 'trollbus.message_id.default_generator';
+    public const DEFAULT_TRANSACTION_PROVIDER = 'trollbus.transaction.default_transaction_provider';
+    public const DEFAULT_ENTITY_FINDER = 'trollbus.entity_handler.default_entity_finder';
+    public const DEFAULT_ENTITY_SAVER = 'trollbus.entity_handler.default_entity_saver';
+    public const DEFAULT_CRITERIA_RESOLVER = 'trollbus.entity_handler.default_criteria_resolver';
+
+    private static int $counter = 0;
+
+    /**
+     * @return non-empty-string
+     */
+    public static function nextHandlerService(): string
+    {
+        $serviceId = \sprintf('trollbus.handler.%s', self::$counter);
+        ++self::$counter;
+
+        return $serviceId;
+    }
+}

--- a/src/TrollbusBundle/DependencyInjection/MessageBusConfigurator.php
+++ b/src/TrollbusBundle/DependencyInjection/MessageBusConfigurator.php
@@ -14,19 +14,60 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 final class MessageBusConfigurator
 {
-    public const MESSAGE_BUS = 'trollbus';
-    public const HANDLER_REGISTRY = 'trollbus.handler_registry';
-    public const HANDLER_TAG = 'trollbus.handler';
-    public const HANDLER_TAG_MESSAGE = 'message';
-    public const HANDLER_TAG_MIDDLEWARES = 'middlewares';
-    public const MIDDLEWARE_TAG = 'trollbus.middleware';
-    public const DEFAULT_MESSAGE_ID_GENERATOR = 'trollbus.message_id.default_generator';
-    public const DEFAULT_TRANSACTION_PROVIDER = 'trollbus.transaction.default_transaction_provider';
-    public const DEFAULT_ENTITY_FINDER = 'trollbus.entity_handler.default_entity_finder';
-    public const DEFAULT_ENTITY_SAVER = 'trollbus.entity_handler.default_entity_saver';
-    public const DEFAULT_CRITERIA_RESOLVER = 'trollbus.entity_handler.default_criteria_resolver';
+    /**
+     * @deprecated Use {@see MessageBusConfiguration::MESSAGE_BUS}, will be remove in `0.3.0`.
+     */
+    public const MESSAGE_BUS = MessageBusConfiguration::MESSAGE_BUS;
 
-    private static int $counter = 0;
+    /**
+     * @deprecated Use {@see MessageBusConfiguration::HANDLER_REGISTRY}, will be remove in `0.3.0`.
+     */
+    public const HANDLER_REGISTRY = MessageBusConfiguration::HANDLER_REGISTRY;
+
+    /**
+     * @deprecated Use {@see MessageBusConfiguration::HANDLER_TAG}, will be remove in `0.3.0`.
+     */
+    public const HANDLER_TAG = MessageBusConfiguration::HANDLER_TAG;
+
+    /**
+     * @deprecated Use {@see MessageBusConfiguration::HANDLER_TAG_MESSAGE}, will be remove in `0.3.0`.
+     */
+    public const HANDLER_TAG_MESSAGE = MessageBusConfiguration::HANDLER_TAG_MESSAGE;
+
+    /**
+     * @deprecated Use {@see MessageBusConfiguration::HANDLER_TAG_MIDDLEWARES}, will be remove in `0.3.0`.
+     */
+    public const HANDLER_TAG_MIDDLEWARES = MessageBusConfiguration::HANDLER_TAG_MIDDLEWARES;
+
+    /**
+     * @deprecated Use {@see MessageBusConfiguration::MIDDLEWARE_TAG}, will be remove in `0.3.0`.
+     */
+    public const MIDDLEWARE_TAG = MessageBusConfiguration::MIDDLEWARE_TAG;
+
+    /**
+     * @deprecated Use {@see MessageBusConfiguration::DEFAULT_MESSAGE_ID_GENERATOR}, will be remove in `0.3.0`.
+     */
+    public const DEFAULT_MESSAGE_ID_GENERATOR = MessageBusConfiguration::DEFAULT_MESSAGE_ID_GENERATOR;
+
+    /**
+     * @deprecated Use {@see MessageBusConfiguration::DEFAULT_TRANSACTION_PROVIDER}, will be remove in `0.3.0`.
+     */
+    public const DEFAULT_TRANSACTION_PROVIDER = MessageBusConfiguration::DEFAULT_TRANSACTION_PROVIDER;
+
+    /**
+     * @deprecated Use {@see MessageBusConfiguration::DEFAULT_ENTITY_FINDER}, will be remove in `0.3.0`.
+     */
+    public const DEFAULT_ENTITY_FINDER = MessageBusConfiguration::DEFAULT_ENTITY_FINDER;
+
+    /**
+     * @deprecated Use {@see MessageBusConfiguration::DEFAULT_ENTITY_SAVER}, will be remove in `0.3.0`.
+     */
+    public const DEFAULT_ENTITY_SAVER = MessageBusConfiguration::DEFAULT_ENTITY_SAVER;
+
+    /**
+     * @deprecated Use {@see MessageBusConfiguration::DEFAULT_CRITERIA_RESOLVER}, will be remove in `0.3.0`.
+     */
+    public const DEFAULT_CRITERIA_RESOLVER = MessageBusConfiguration::DEFAULT_CRITERIA_RESOLVER;
 
     public function __construct(
         private readonly ContainerConfigurator $di,
@@ -45,7 +86,7 @@ final class MessageBusConfigurator
     public function handler(string $message, string $service, array $middlewares = []): self
     {
         if (\count($middlewares) > 0) {
-            $decoratedService = self::nextHandlerService();
+            $decoratedService = MessageBusConfiguration::nextHandlerService();
             $this->di
                 ->services()
                 ->set($decoratedService, HandlerWithMiddlewares::class)
@@ -60,7 +101,7 @@ final class MessageBusConfigurator
         $this->di
             ->services()
             ->get($service)
-                ->tag(self::HANDLER_TAG, [self::HANDLER_TAG_MESSAGE => $message]);
+                ->tag(MessageBusConfiguration::HANDLER_TAG, [MessageBusConfiguration::HANDLER_TAG_MESSAGE => $message]);
 
         return $this;
     }
@@ -79,7 +120,7 @@ final class MessageBusConfigurator
         ?string $handlerId = null,
         array $middlewares = [],
     ): self {
-        $handlerService = self::nextHandlerService();
+        $handlerService = MessageBusConfiguration::nextHandlerService();
         $this->di
             ->services()
             ->set($handlerService, CallableHandler::class)
@@ -109,13 +150,13 @@ final class MessageBusConfigurator
         string $handlerMethod,
         array $findBy,
         ?string $factoryMethod = null,
-        string $entityFinder = self::DEFAULT_ENTITY_FINDER,
-        string $entitySaver = self::DEFAULT_ENTITY_SAVER,
-        string $criteriaResolver = self::DEFAULT_CRITERIA_RESOLVER,
+        string $entityFinder = MessageBusConfiguration::DEFAULT_ENTITY_FINDER,
+        string $entitySaver = MessageBusConfiguration::DEFAULT_ENTITY_SAVER,
+        string $criteriaResolver = MessageBusConfiguration::DEFAULT_CRITERIA_RESOLVER,
         ?string $handlerId = null,
         array $middlewares = [],
     ): self {
-        $handlerService = self::nextHandlerService();
+        $handlerService = MessageBusConfiguration::nextHandlerService();
         $this->di
             ->services()
             ->set($handlerService, EntityHandler::class)
@@ -146,11 +187,11 @@ final class MessageBusConfigurator
         string $message,
         string $entityClass,
         string $handlerMethod,
-        string $entitySaver = self::DEFAULT_ENTITY_SAVER,
+        string $entitySaver = MessageBusConfiguration::DEFAULT_ENTITY_SAVER,
         ?string $handlerId = null,
         array $middlewares = [],
     ): self {
-        $handlerService = self::nextHandlerService();
+        $handlerService = MessageBusConfiguration::nextHandlerService();
         $this->di
             ->services()
             ->set($handlerService, EntityFactoryHandler::class)
@@ -172,19 +213,18 @@ final class MessageBusConfigurator
         $this->di
             ->services()
             ->get($service)
-                ->tag(self::MIDDLEWARE_TAG, ['priority' => $priority]);
+                ->tag(MessageBusConfiguration::MIDDLEWARE_TAG, ['priority' => $priority]);
 
         return $this;
     }
 
     /**
      * @return non-empty-string
+     *
+     * @deprecated Use {@see MessageBusConfiguration::nextHandlerService()}, will be remove in `0.3.0`.
      */
     public static function nextHandlerService(): string
     {
-        $serviceId = \sprintf('trollbus.handler.%s', self::$counter);
-        ++self::$counter;
-
-        return $serviceId;
+        return MessageBusConfiguration::nextHandlerService();
     }
 }

--- a/src/TrollbusBundle/TrollbusBundle.php
+++ b/src/TrollbusBundle/TrollbusBundle.php
@@ -27,7 +27,7 @@ use Trollbus\MessageBus\MessageId\RandomMessageIdGenerator;
 use Trollbus\MessageBus\Transaction\WrapInTransactionMiddleware;
 use Trollbus\TrollbusBundle\DependencyInjection\CompilerPass\DebugHandlerPass;
 use Trollbus\TrollbusBundle\DependencyInjection\CompilerPass\HandlerRegistryPass;
-use Trollbus\TrollbusBundle\DependencyInjection\MessageBusConfigurator;
+use Trollbus\TrollbusBundle\DependencyInjection\MessageBusConfiguration;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
@@ -112,10 +112,10 @@ final class TrollbusBundle extends AbstractBundle
             ->services()
             ->set(MessageBus::class)
                 ->args([
-                    service(MessageBusConfigurator::HANDLER_REGISTRY),
-                    tagged_iterator(MessageBusConfigurator::MIDDLEWARE_TAG),
+                    service(MessageBusConfiguration::HANDLER_REGISTRY),
+                    tagged_iterator(MessageBusConfiguration::MIDDLEWARE_TAG),
                 ])
-            ->alias(MessageBusConfigurator::MESSAGE_BUS, MessageBus::class)
+            ->alias(MessageBusConfiguration::MESSAGE_BUS, MessageBus::class)
                 ->public();
     }
 
@@ -146,7 +146,7 @@ final class TrollbusBundle extends AbstractBundle
                 ->args([
                     isset($config['created_at']['clock']) ? service($config['created_at']['clock']) : null,
                 ])
-                ->tag(MessageBusConfigurator::MIDDLEWARE_TAG, ['priority' => 1000]);
+                ->tag(MessageBusConfiguration::MIDDLEWARE_TAG, ['priority' => 1000]);
     }
 
     /**
@@ -176,7 +176,7 @@ final class TrollbusBundle extends AbstractBundle
                 ->args([
                     service($config['logger']['logger']),
                 ])
-                ->tag(MessageBusConfigurator::MIDDLEWARE_TAG, ['priority' => 900]);
+                ->tag(MessageBusConfiguration::MIDDLEWARE_TAG, ['priority' => 900]);
     }
 
     /**
@@ -189,7 +189,7 @@ final class TrollbusBundle extends AbstractBundle
                 ->canBeDisabled()
                 ->children()
                     ->scalarNode('generator')
-                        ->defaultValue(MessageBusConfigurator::DEFAULT_MESSAGE_ID_GENERATOR);
+                        ->defaultValue(MessageBusConfiguration::DEFAULT_MESSAGE_ID_GENERATOR);
     }
 
     /**
@@ -203,8 +203,8 @@ final class TrollbusBundle extends AbstractBundle
 
         $services->set(RandomMessageIdGenerator::class);
 
-        if (!$builder->has(MessageBusConfigurator::DEFAULT_MESSAGE_ID_GENERATOR)) {
-            $services->alias(MessageBusConfigurator::DEFAULT_MESSAGE_ID_GENERATOR, RandomMessageIdGenerator::class);
+        if (!$builder->has(MessageBusConfiguration::DEFAULT_MESSAGE_ID_GENERATOR)) {
+            $services->alias(MessageBusConfiguration::DEFAULT_MESSAGE_ID_GENERATOR, RandomMessageIdGenerator::class);
         }
 
         $services
@@ -212,13 +212,13 @@ final class TrollbusBundle extends AbstractBundle
                 ->args([
                     service($config['message_id']['generator']),
                 ])
-                ->tag(MessageBusConfigurator::MIDDLEWARE_TAG, ['priority' => 810])
+                ->tag(MessageBusConfiguration::MIDDLEWARE_TAG, ['priority' => 810])
 
             ->set(CorrelationIdMiddleware::class)
-                ->tag(MessageBusConfigurator::MIDDLEWARE_TAG, ['priority' => 800])
+                ->tag(MessageBusConfiguration::MIDDLEWARE_TAG, ['priority' => 800])
 
             ->set(CausationIdMiddleware::class)
-                ->tag(MessageBusConfigurator::MIDDLEWARE_TAG, ['priority' => 800]);
+                ->tag(MessageBusConfiguration::MIDDLEWARE_TAG, ['priority' => 800]);
     }
 
     /**
@@ -231,7 +231,7 @@ final class TrollbusBundle extends AbstractBundle
             ->canBeEnabled()
                 ->children()
                     ->scalarNode('transaction_provider')
-                        ->defaultValue(MessageBusConfigurator::DEFAULT_TRANSACTION_PROVIDER);
+                        ->defaultValue(MessageBusConfiguration::DEFAULT_TRANSACTION_PROVIDER);
     }
 
     /**
@@ -248,7 +248,7 @@ final class TrollbusBundle extends AbstractBundle
                 ->args([
                     service($config['transaction']['transaction_provider']),
                 ])
-                ->tag(MessageBusConfigurator::MIDDLEWARE_TAG, ['priority' => 700]);
+                ->tag(MessageBusConfiguration::MIDDLEWARE_TAG, ['priority' => 700]);
     }
 
     /**
@@ -261,13 +261,13 @@ final class TrollbusBundle extends AbstractBundle
             ->canBeEnabled()
             ->children()
                 ->scalarNode('entity_finder')
-                    ->defaultValue(MessageBusConfigurator::DEFAULT_ENTITY_FINDER)
+                    ->defaultValue(MessageBusConfiguration::DEFAULT_ENTITY_FINDER)
                     ->end()
                 ->scalarNode('entity_saver')
-                    ->defaultValue(MessageBusConfigurator::DEFAULT_ENTITY_SAVER)
+                    ->defaultValue(MessageBusConfiguration::DEFAULT_ENTITY_SAVER)
                     ->end()
                 ->scalarNode('criteria_resolver')
-                    ->defaultValue(MessageBusConfigurator::DEFAULT_CRITERIA_RESOLVER);
+                    ->defaultValue(MessageBusConfiguration::DEFAULT_CRITERIA_RESOLVER);
     }
 
     /**
@@ -279,20 +279,20 @@ final class TrollbusBundle extends AbstractBundle
             return;
         }
 
-        if (MessageBusConfigurator::DEFAULT_ENTITY_FINDER !== $config['entity_handler']['entity_finder']) {
-            $services->alias(MessageBusConfigurator::DEFAULT_ENTITY_FINDER, $config['entity_handler']['entity_finder']);
+        if (MessageBusConfiguration::DEFAULT_ENTITY_FINDER !== $config['entity_handler']['entity_finder']) {
+            $services->alias(MessageBusConfiguration::DEFAULT_ENTITY_FINDER, $config['entity_handler']['entity_finder']);
         }
 
-        if (MessageBusConfigurator::DEFAULT_ENTITY_SAVER !== $config['entity_handler']['entity_saver']) {
-            $services->alias(MessageBusConfigurator::DEFAULT_ENTITY_SAVER, $config['entity_handler']['entity_saver']);
+        if (MessageBusConfiguration::DEFAULT_ENTITY_SAVER !== $config['entity_handler']['entity_saver']) {
+            $services->alias(MessageBusConfiguration::DEFAULT_ENTITY_SAVER, $config['entity_handler']['entity_saver']);
         }
 
         $services->set(PropertyCriteriaResolver::class);
 
-        if (MessageBusConfigurator::DEFAULT_CRITERIA_RESOLVER === $config['entity_handler']['criteria_resolver']) {
-            $services->alias(MessageBusConfigurator::DEFAULT_CRITERIA_RESOLVER, PropertyCriteriaResolver::class);
+        if (MessageBusConfiguration::DEFAULT_CRITERIA_RESOLVER === $config['entity_handler']['criteria_resolver']) {
+            $services->alias(MessageBusConfiguration::DEFAULT_CRITERIA_RESOLVER, PropertyCriteriaResolver::class);
         } else {
-            $services->alias(MessageBusConfigurator::DEFAULT_CRITERIA_RESOLVER, $config['entity_handler']['criteria_resolver']);
+            $services->alias(MessageBusConfiguration::DEFAULT_CRITERIA_RESOLVER, $config['entity_handler']['criteria_resolver']);
         }
     }
 
@@ -348,16 +348,16 @@ final class TrollbusBundle extends AbstractBundle
                     $config['doctrine_orm_bridge']['entity_saver_flush'],
                 ]);
 
-        if (!$builder->has(MessageBusConfigurator::DEFAULT_TRANSACTION_PROVIDER)) {
-            $services->alias(MessageBusConfigurator::DEFAULT_TRANSACTION_PROVIDER, DoctrineTransactionProvider::class);
+        if (!$builder->has(MessageBusConfiguration::DEFAULT_TRANSACTION_PROVIDER)) {
+            $services->alias(MessageBusConfiguration::DEFAULT_TRANSACTION_PROVIDER, DoctrineTransactionProvider::class);
         }
 
-        if (!$builder->has(MessageBusConfigurator::DEFAULT_ENTITY_FINDER)) {
-            $services->alias(MessageBusConfigurator::DEFAULT_ENTITY_FINDER, DoctrineEntityFinder::class);
+        if (!$builder->has(MessageBusConfiguration::DEFAULT_ENTITY_FINDER)) {
+            $services->alias(MessageBusConfiguration::DEFAULT_ENTITY_FINDER, DoctrineEntityFinder::class);
         }
 
-        if (!$builder->has(MessageBusConfigurator::DEFAULT_ENTITY_SAVER)) {
-            $services->alias(MessageBusConfigurator::DEFAULT_ENTITY_SAVER, DoctrineEntitySaver::class);
+        if (!$builder->has(MessageBusConfiguration::DEFAULT_ENTITY_SAVER)) {
+            $services->alias(MessageBusConfiguration::DEFAULT_ENTITY_SAVER, DoctrineEntitySaver::class);
         }
 
         if ($config['doctrine_orm_bridge']['flusher']) {


### PR DESCRIPTION
MessageBusConfiguration is a single source of truth for service container configuration.
MessageBusConfigurator used to be responsible for this. Refactor all classes for using MessageBusConfiguration instead MessageBusConfigurator.