### PR TITLE
Simplify generics of dispatch() method in MessageBus and MessageContext

### DIFF
--- a/src/MessageBus/MessageBus.php
+++ b/src/MessageBus/MessageBus.php
@@ -21,8 +21,9 @@ final class MessageBus
 
     /**
      * @template TResult
-     * @template TMessage of Message<TResult>
-     * @param TMessage|Envelope<TResult, TMessage> $messageOrEnvelop
+     *
+     * @param Message<TResult>|Envelope<TResult, Message<TResult>> $messageOrEnvelop
+     *
      * @return (TResult is void ? null : TResult)
      */
     public function dispatch(Message|Envelope $messageOrEnvelop): mixed
@@ -33,7 +34,9 @@ final class MessageBus
     /**
      * @template TResult
      * @template TMessage of Message<TResult>
+     *
      * @param TMessage|Envelope<TResult, TMessage> $messageOrEnvelop
+     *
      * @return MessageContext<TResult, TMessage>
      */
     public function startContext(Message|Envelope $messageOrEnvelop): MessageContext
@@ -44,7 +47,9 @@ final class MessageBus
     /**
      * @template TResult
      * @template TMessage of Message<TResult>
+     *
      * @param MessageContext<TResult, TMessage> $messageContext
+     *
      * @return (TResult is void ? null : TResult)
      */
     public function handleContext(MessageContext $messageContext): mixed

--- a/src/MessageBus/MessageContext.php
+++ b/src/MessageBus/MessageContext.php
@@ -27,7 +27,9 @@ final class MessageContext extends ReadonlyMessageContext
     /**
      * @template TTResult
      * @template TTMessage of Message<TTResult>
+     *
      * @param TTMessage|Envelope<TTResult, TTMessage> $messageOrEnvelop
+     *
      * @return self<TTResult, TTMessage>
      */
     public static function start(MessageBus $messageBus, Message|Envelope $messageOrEnvelop): self
@@ -37,8 +39,9 @@ final class MessageContext extends ReadonlyMessageContext
 
     /**
      * @template TTResult
-     * @template TTMessage of Message<TTResult>
-     * @param TTMessage|Envelope<TTResult, TTMessage> $messageOrEnvelop
+     *
+     * @param Message<TTResult>|Envelope<TTResult, Message<TTResult>> $messageOrEnvelop
+     *
      * @return (TTResult is void ? null : TTResult)
      */
     public function dispatch(Message|Envelope $messageOrEnvelop): mixed


### PR DESCRIPTION
It was created for compatibility with PHPStorm autocompletion. This is not entirely correct from the point of view of static analysis. But it's comfort works with IDE.

Also, for `dispatch()` method the correct return result type is more important, that more complex argument type.