### PR TITLE
MessageTypeResolver

### DIFF
--- a/src/MessageBus/Async/MessageType/AddMessageTypeMiddleware.php
+++ b/src/MessageBus/Async/MessageType/AddMessageTypeMiddleware.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\MessageType;
+
+use Trollbus\MessageBus\MessageContext;
+use Trollbus\MessageBus\Middleware\Middleware;
+use Trollbus\MessageBus\Middleware\Pipeline;
+
+final class AddMessageTypeMiddleware implements Middleware
+{
+    public function __construct(
+        private readonly MessageTypeResolver $resolver,
+    ) {}
+
+    public function handle(MessageContext $messageContext, Pipeline $pipeline): mixed
+    {
+        if ($messageContext->hasStamp(MessageType::class)) {
+            return $pipeline->continue();
+        }
+
+        $messageContext->addStamps(new MessageType(type: $this->resolver->resolveType($messageContext->getMessageClass())));
+
+        return $pipeline->continue();
+    }
+}

--- a/src/MessageBus/Async/MessageType/ChainMessageTypeResolver.php
+++ b/src/MessageBus/Async/MessageType/ChainMessageTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\MessageType;
+
+final class ChainMessageTypeResolver implements MessageTypeResolver
+{
+    /**
+     * @param iterable<MessageTypeResolver> $resolvers
+     */
+    public function __construct(
+        private readonly iterable $resolvers,
+    ) {}
+
+    public function resolveType(string $class): string
+    {
+        foreach ($this->resolvers as $resolver) {
+            try {
+                return $resolver->resolveType($class);
+            } catch (UnsupportedMessageClass) {
+            }
+        }
+
+        throw UnsupportedMessageClass::create($class);
+    }
+
+    public function resolveClass(string $type): string
+    {
+        foreach ($this->resolvers as $resolver) {
+            try {
+                return $resolver->resolveClass($type);
+            } catch (UnsupportedMessageType) {
+            }
+        }
+
+        throw UnsupportedMessageType::create($type);
+    }
+}

--- a/src/MessageBus/Async/MessageType/ClassToTypeMapMessageTypeResolver.php
+++ b/src/MessageBus/Async/MessageType/ClassToTypeMapMessageTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\MessageType;
+
+use Trollbus\Message\Message;
+
+final class ClassToTypeMapMessageTypeResolver implements MessageTypeResolver
+{
+    /**
+     * @param array<class-string<Message>, non-empty-string> $classToTypeMap
+     */
+    public function __construct(
+        private array $classToTypeMap,
+    ) {
+        $diff = array_diff_assoc($this->classToTypeMap, array_unique($this->classToTypeMap));
+
+        if ([] !== $diff) {
+            throw new \LogicException(\sprintf('Duplicate message types: %s.', implode(', ', $diff)));
+        }
+    }
+
+    public function resolveType(string $class): string
+    {
+        return $this->classToTypeMap[$class] ?? throw UnsupportedMessageClass::create($class);
+    }
+
+    public function resolveClass(string $type): string
+    {
+        $class = array_search($type, $this->classToTypeMap, true);
+
+        if (false === $class) {
+            throw UnsupportedMessageType::create($type);
+        }
+
+        return $class;
+    }
+}

--- a/src/MessageBus/Async/MessageType/MessageType.php
+++ b/src/MessageBus/Async/MessageType/MessageType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\MessageType;
+
+use Trollbus\MessageBus\Stamp;
+
+final class MessageType implements Stamp
+{
+    /**
+     * @param non-empty-string $type
+     */
+    public function __construct(
+        public readonly string $type,
+    ) {}
+}

--- a/src/MessageBus/Async/MessageType/MessageTypeNotDefined.php
+++ b/src/MessageBus/Async/MessageType/MessageTypeNotDefined.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\MessageType;
+
+final class MessageTypeNotDefined extends \Exception
+{
+    public static function create(): self
+    {
+        return new self('Message type not defined.');
+    }
+}

--- a/src/MessageBus/Async/MessageType/MessageTypeResolver.php
+++ b/src/MessageBus/Async/MessageType/MessageTypeResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\MessageType;
+
+use Trollbus\Message\Message;
+
+interface MessageTypeResolver
+{
+    /**
+     * @param class-string<Message> $class
+     *
+     * @return non-empty-string
+     *
+     * @throws UnsupportedMessageClass
+     */
+    public function resolveType(string $class): string;
+
+    /**
+     * @param non-empty-string $type
+     *
+     * @return class-string<Message>
+     *
+     * @throws UnsupportedMessageType
+     */
+    public function resolveClass(string $type): string;
+}

--- a/src/MessageBus/Async/MessageType/OrigClassMessageTypeResolver.php
+++ b/src/MessageBus/Async/MessageType/OrigClassMessageTypeResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\MessageType;
+
+use Trollbus\Message\Message;
+
+final class OrigClassMessageTypeResolver implements MessageTypeResolver
+{
+    public function resolveType(string $class): string
+    {
+        // Normalize class name
+        return (new \ReflectionClass($class))->getName();
+    }
+
+    public function resolveClass(string $type): string
+    {
+        if (!(class_exists($type) && is_subclass_of($type, Message::class, true))) {
+            /** @psalm-suppress ArgumentTypeCoercion type of $type variable is always non-empty-string */
+            throw UnsupportedMessageType::create($type);
+        }
+
+        // Normalize class name
+        return (new \ReflectionClass($type))->getName();
+    }
+}

--- a/src/MessageBus/Async/MessageType/UnsupportedMessageClass.php
+++ b/src/MessageBus/Async/MessageType/UnsupportedMessageClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\MessageType;
+
+use Trollbus\Message\Message;
+
+final class UnsupportedMessageClass extends \Exception
+{
+    /**
+     * @param class-string<Message> $class
+     */
+    public static function create(string $class): self
+    {
+        return new self("Can not resolve message type for class \"{$class}\".");
+    }
+}

--- a/src/MessageBus/Async/MessageType/UnsupportedMessageType.php
+++ b/src/MessageBus/Async/MessageType/UnsupportedMessageType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\MessageType;
+
+final class UnsupportedMessageType extends \Exception
+{
+    /**
+     * @param non-empty-string $type
+     */
+    public static function create(string $type): self
+    {
+        return new self("Can not resolve message class for type \"{$type}\".");
+    }
+}

--- a/tests/MessageBus/Async/MessageType/BarMessage.php
+++ b/tests/MessageBus/Async/MessageType/BarMessage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\MessageBus\Async\MessageType;
+
+use Trollbus\Message\Message;
+
+/**
+ * @implements Message<void>
+ */
+final class BarMessage implements Message
+{
+    public function __construct() {}
+}

--- a/tests/MessageBus/Async/MessageType/ChainMessageTypeResolverTest.php
+++ b/tests/MessageBus/Async/MessageType/ChainMessageTypeResolverTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\MessageBus\Async\MessageType;
+
+use PHPUnit\Framework\TestCase;
+use Trollbus\MessageBus\Async\MessageType\ChainMessageTypeResolver;
+use Trollbus\MessageBus\Async\MessageType\ClassToTypeMapMessageTypeResolver;
+use Trollbus\MessageBus\Async\MessageType\OrigClassMessageTypeResolver;
+use Trollbus\MessageBus\Async\MessageType\UnsupportedMessageClass;
+use Trollbus\MessageBus\Async\MessageType\UnsupportedMessageType;
+
+final class ChainMessageTypeResolverTest extends TestCase
+{
+    public function testResolveTypeUsesFirstSupportingResolver(): void
+    {
+        $resolver = new ChainMessageTypeResolver([
+            new ClassToTypeMapMessageTypeResolver([FooMessage::class => 'foo']),
+            new OrigClassMessageTypeResolver(),
+        ]);
+
+        self::assertSame('foo', $resolver->resolveType(FooMessage::class));
+        self::assertSame(BarMessage::class, $resolver->resolveType(BarMessage::class));
+    }
+
+    public function testResolveTypeThrowsWhenNoResolverSupportsClass(): void
+    {
+        $this->expectException(UnsupportedMessageClass::class);
+        $this->expectExceptionMessage(\sprintf('Can not resolve message type for class "%s".', FooMessage::class));
+
+        $resolver = new ChainMessageTypeResolver([
+            new ClassToTypeMapMessageTypeResolver([]),
+        ]);
+        $resolver->resolveType(FooMessage::class);
+    }
+
+    public function testResolveClassUsesFirstSupportingResolver(): void
+    {
+        $resolver = new ChainMessageTypeResolver([
+            new ClassToTypeMapMessageTypeResolver([FooMessage::class => 'foo']),
+            new OrigClassMessageTypeResolver(),
+        ]);
+
+        self::assertSame(FooMessage::class, $resolver->resolveClass('foo'));
+        self::assertSame(FooMessage::class, $resolver->resolveClass(FooMessage::class));
+        self::assertSame(BarMessage::class, $resolver->resolveClass(BarMessage::class));
+    }
+
+    public function testResolveClassThrowsWhenNoResolverSupportsType(): void
+    {
+        self::expectException(UnsupportedMessageType::class);
+        self::expectExceptionMessage('Can not resolve message class for type "resolved-type".');
+
+        $resolver = new ChainMessageTypeResolver([
+            new ClassToTypeMapMessageTypeResolver([]),
+        ]);
+        $resolver->resolveClass('resolved-type');
+    }
+}

--- a/tests/MessageBus/Async/MessageType/ClassToTypeMapMessageTypeResolverTest.php
+++ b/tests/MessageBus/Async/MessageType/ClassToTypeMapMessageTypeResolverTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\MessageBus\Async\MessageType;
+
+use PHPUnit\Framework\TestCase;
+use Trollbus\MessageBus\Async\MessageType\ClassToTypeMapMessageTypeResolver;
+use Trollbus\MessageBus\Async\MessageType\UnsupportedMessageClass;
+use Trollbus\MessageBus\Async\MessageType\UnsupportedMessageType;
+
+final class ClassToTypeMapMessageTypeResolverTest extends TestCase
+{
+    public function testConstructorThrowsLogicExceptionOnDuplicateType(): void
+    {
+        self::expectException(\LogicException::class);
+        self::expectExceptionMessage('Duplicate message types: foo.');
+
+        new ClassToTypeMapMessageTypeResolver([FooMessage::class => 'foo', BarMessage::class => 'foo']);
+    }
+
+    public function testResolveTypeReturnsTypeFromMap(): void
+    {
+        $resolver = new ClassToTypeMapMessageTypeResolver([FooMessage::class => 'foo']);
+
+        self::assertSame('foo', $resolver->resolveType(FooMessage::class));
+    }
+
+    public function testResolveTypeThrowsOnUnknownClass(): void
+    {
+        self::expectException(UnsupportedMessageClass::class);
+        self::expectExceptionMessage(\sprintf('Can not resolve message type for class "%s".', FooMessage::class));
+
+        $resolver = new ClassToTypeMapMessageTypeResolver([]);
+        $resolver->resolveType(FooMessage::class);
+    }
+
+    public function testResolveClassReturnsClassFromType(): void
+    {
+        $resolver = new ClassToTypeMapMessageTypeResolver([FooMessage::class => 'foo']);
+
+        self::assertSame(FooMessage::class, $resolver->resolveClass('foo'));
+    }
+
+    public function testResolveClassThrowsOnUnknownType(): void
+    {
+        self::expectException(UnsupportedMessageType::class);
+        self::expectExceptionMessage('Can not resolve message class for type "unknown-type".');
+
+        $resolver = new ClassToTypeMapMessageTypeResolver([]);
+        $resolver->resolveClass('unknown-type');
+    }
+}

--- a/tests/MessageBus/Async/MessageType/FooMessage.php
+++ b/tests/MessageBus/Async/MessageType/FooMessage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\MessageBus\Async\MessageType;
+
+use Trollbus\Message\Message;
+
+/**
+ * @implements Message<void>
+ */
+final class FooMessage implements Message
+{
+    public function __construct() {}
+}

--- a/tests/MessageBus/Async/MessageType/OrigClassMessageTypeResolverTest.php
+++ b/tests/MessageBus/Async/MessageType/OrigClassMessageTypeResolverTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\MessageBus\Async\MessageType;
+
+use PHPUnit\Framework\TestCase;
+use Trollbus\MessageBus\Async\MessageType\OrigClassMessageTypeResolver;
+use Trollbus\MessageBus\Async\MessageType\UnsupportedMessageType;
+
+final class OrigClassMessageTypeResolverTest extends TestCase
+{
+    public function testResolveTypeReturnsNormalizedClassName(): void
+    {
+        $resolver = new OrigClassMessageTypeResolver();
+
+        self::assertSame(FooMessage::class, $resolver->resolveType(FooMessage::class));
+    }
+
+    public function testResolveClassReturnsNormalizedClassForMessage(): void
+    {
+        $resolver = new OrigClassMessageTypeResolver();
+
+        self::assertSame(FooMessage::class, $resolver->resolveClass(FooMessage::class));
+    }
+
+    public function testResolveClassThrowsOnUnknownClass(): void
+    {
+        self::expectException(UnsupportedMessageType::class);
+
+        $resolver = new OrigClassMessageTypeResolver();
+        $resolver->resolveClass('Unknown\Class\That\Does\Not\Exist');
+    }
+
+    public function testResolveClassThrowsWhenClassIsNotAMessage(): void
+    {
+        self::expectException(UnsupportedMessageType::class);
+
+        $resolver = new OrigClassMessageTypeResolver();
+        $resolver->resolveClass(\stdClass::class);
+    }
+}


### PR DESCRIPTION
**Why MessageTypeResolver exists:**

Broker (RabbitMQ, Kafka, etc.) knows nothing about PHP classes. When a message arrives, we get a raw string/array and don't know which class to denormalize it into.

`MessageTypeResolver` solves this - it maps message classes to string identifiers and back:
- On send: class → type (stored in headers/metadata)
- On receive: type → class (to know which object to instantiate)

**Implementations:**

- `OrigClassMessageTypeResolver` — uses the full class name as the type (e.g., `App\Message\UserRegistered`). Zero config but long and rigid.

- `ClassToTypeMapMessageTypeResolver` — uses a manual mapping: `['App\Message\UserRegistered' => 'user.registered']`. Short, human-readable types with decoupled class names.

- `ChainMessageTypeResolver` — iterates over a chain of resolvers until one returns a result. Allows combining strategies: e.g., check custom mapping first, fallback to default.

**AddMessageTypeMiddleware:**

Middleware that calls `MessageTypeResolver::resolveType()` and adds a `MessageType` stamp to the `Envelope`. On the consumer side, this stamp is used to determine which class to denormalize the message into.

Part of #66