### PR TITLE
ObjectNormalizer, ObjectDenormalizer, PhpNativeSerializer

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -10,6 +10,7 @@
     cacheDirectory="var/psalm"
     ensureOverrideAttribute="false"
     findUnusedIssueHandlerSuppression="false"
+    reportMixedIssues="false"
 >
     <issueHandlers>
         <InternalClass errorLevel="error"/>

--- a/src/MessageBus/Async/ObjectNormalizer/DenormalizationError.php
+++ b/src/MessageBus/Async/ObjectNormalizer/DenormalizationError.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\ObjectNormalizer;
+
+final class DenormalizationError extends \Exception
+{
+    /**
+     * @param class-string $class
+     */
+    public static function create(string $class): self
+    {
+        return new self("Can not denormalize data to object instance \"{$class}\".");
+    }
+}

--- a/src/MessageBus/Async/ObjectNormalizer/ObjectDenormalizer.php
+++ b/src/MessageBus/Async/ObjectNormalizer/ObjectDenormalizer.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\ObjectNormalizer;
+
+interface ObjectDenormalizer
+{
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $class
+     *
+     * @return T
+     *
+     * @throws DenormalizationError
+     */
+    public function denormalize(mixed $data, string $class): object;
+}

--- a/src/MessageBus/Async/ObjectNormalizer/ObjectNormalizer.php
+++ b/src/MessageBus/Async/ObjectNormalizer/ObjectNormalizer.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\ObjectNormalizer;
+
+interface ObjectNormalizer
+{
+    public function normalize(object $object): mixed;
+}

--- a/src/MessageBus/Async/ObjectNormalizer/PhpNativeSerializer.php
+++ b/src/MessageBus/Async/ObjectNormalizer/PhpNativeSerializer.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\MessageBus\Async\ObjectNormalizer;
+
+final class PhpNativeSerializer implements ObjectNormalizer, ObjectDenormalizer
+{
+    public function normalize(object $object): mixed
+    {
+        return serialize($object);
+    }
+
+    public function denormalize(mixed $data, string $class): object
+    {
+        if (\is_string($data)) {
+            $object = unserialize($data);
+
+            if ($object instanceof $class) {
+                return $object;
+            }
+        }
+
+        throw DenormalizationError::create($class);
+    }
+}

--- a/tests/MessageBus/Async/ObjectNormalizer/PhpNativeSerializerTest.php
+++ b/tests/MessageBus/Async/ObjectNormalizer/PhpNativeSerializerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\MessageBus\Async\ObjectNormalizer;
+
+use PHPUnit\Framework\TestCase;
+use Trollbus\MessageBus\Async\ObjectNormalizer\DenormalizationError;
+use Trollbus\MessageBus\Async\ObjectNormalizer\PhpNativeSerializer;
+
+final class PhpNativeSerializerTest extends TestCase
+{
+    public function testNormalizeAndDenormalizeRoundTrip(): void
+    {
+        $serializer = new PhpNativeSerializer();
+
+        $object = new SomeMessage('value');
+
+        $data = $serializer->normalize($object);
+
+        self::assertIsString($data);
+
+        $deserializedObject = $serializer->denormalize($data, SomeMessage::class);
+
+        self::assertInstanceOf(SomeMessage::class, $deserializedObject);
+        self::assertEquals($object, $deserializedObject);
+    }
+
+    public function testDenormalizeThrowsWhenDataIsNotString(): void
+    {
+        self::expectException(DenormalizationError::class);
+        self::expectExceptionMessage('Can not denormalize data to object instance "DateTimeImmutable".');
+
+        $serializer = new PhpNativeSerializer();
+        $serializer->denormalize(123, \DateTimeImmutable::class);
+    }
+
+    public function testDenormalizeThrowsWhenInstanceDoesNotMatchClass(): void
+    {
+        self::expectException(DenormalizationError::class);
+        self::expectExceptionMessage('Can not denormalize data to object instance "DateTimeImmutable".');
+
+        $serializer = new PhpNativeSerializer();
+        $data = $serializer->normalize(new \stdClass());
+
+        $serializer->denormalize($data, \DateTimeImmutable::class);
+    }
+}

--- a/tests/MessageBus/Async/ObjectNormalizer/SomeMessage.php
+++ b/tests/MessageBus/Async/ObjectNormalizer/SomeMessage.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trollbus\Tests\MessageBus\Async\ObjectNormalizer;
+
+use Trollbus\Message\Message;
+
+/**
+ * @implements Message<void>
+ */
+final class SomeMessage implements Message
+{
+    public function __construct(
+        public string $value,
+    ) {}
+}


### PR DESCRIPTION
**Why ObjectNormalizer and ObjectDenormalizer interfaces exist:**

They split the responsibility of object transformation into two stages:
- `ObjectNormalizer` - converts an object into a format suitable for sending to the broker.
- `ObjectDenormalizer` - restores an object from received data.

This allows swapping the serialization strategy (JSON, Protobuf, PHP-native, etc.) without changing the Message Bus logic.

**What PhpNativeSerializer does:**

A simple implementation of both interfaces using `serialize()` and `unserialize()` native php funcrtions. Suitable for internal systems where speed and preserving complex objects matter, and cross-language compatibility is not required.

Part of #66